### PR TITLE
Update to the campzone badge documentation

### DIFF
--- a/content/Badges/CampZone 2019/_index.md
+++ b/content/Badges/CampZone 2019/_index.md
@@ -4,4 +4,23 @@ nodateline: true
 weight: -4
 ---
 
-To-Do
+Work in progress doc
+
+In Ubuntu
+
+Install screen:
+
+<code> sudo apt install screen </code>
+
+
+Then add yourself to the network users
+
+<code> sudo usermod -a -G dialout -currentUser- </code>
+
+login or reboot
+
+then connect and switch on the badge.
+
+Then in the terminal execute the following:
+
+<code> screen /dev/ttyUSB0 115200 </code>


### PR DESCRIPTION
added a part on getting access in Ubuntu